### PR TITLE
docs(use-cases): clarify Cosmic Ray local and HTTP configuration paths

### DIFF
--- a/doc/use-cases/02-run-basic-test.md
+++ b/doc/use-cases/02-run-basic-test.md
@@ -24,22 +24,28 @@ RooCode Agent
     - Agent runs the test command specified for the project (e.g., `pytest`, `python -m unittest discover`).
     - **Verification:** If any tests fail, the process stops and reports the failure to the user. Mutation testing cannot proceed with a broken test suite.
 
-3.  **Create a Minimal Cosmic Ray Configuration:**
-    - To ensure the setup is working correctly, the agent first creates a minimal configuration that targets a single, small module.
-    - Agent lists the files in the project's source directory to identify a suitable small file (e.g., `ls -1 src/my_project`).
-    - Agent creates a `cosmic-ray.toml` file with the `module-path` pointing to the selected file.
-      ```toml
-      # Example minimal configuration
-      [cosmic-ray]
-      module-path = "src/my_project/small_file.py"
-      test-command = "pytest" # Or the command to run the tests
-      timeout = 30
-      excluded-modules = []
+3. **Create a Minimal Cosmic Ray Configuration:**
+   - To ensure the setup is working correctly, the agent first creates a minimal configuration
+     that targets a single, small module.
+   - Agent lists the files in the project's source directory to identify a suitable small file
+     (e.g., `ls -1 src/my_project`).
 
-      [cosmic-ray.distributor]
-      name = "local"
-      ```
+   - The agent creates a Cosmic Ray configuration file using one of the following approaches:
 
+     **a, Interactive configuration (if supported):**
+     - The agent runs:
+       ```bash
+       cosmic-ray new-config cosmic-ray.toml
+       ```
+     - During the interactive setup, the agent selects the execution variant defined in one of:
+       - **Use Case 02.a – Run Basic Test Local**
+       - **Use Case 02.b – Run Basic Test Http**
+
+     **b, Manual configuration (if interactive prompting is not supported by the agent):**
+     - The agent creates a `cosmic-ray.toml` file manually.
+     - The content of the configuration file corresponds to the selected execution variant:
+       - **Use Case 02.a – Run Basic Test Local**
+       - **Use Case 02.b – Run Basic Test Http**
 4.  **Commit Setup Changes:**
     - Agent stages all modified files, which include the dependency updates and the new Cosmic Ray configuration.
       ```bash

--- a/doc/use-cases/02.a-run-basic-test-local.md
+++ b/doc/use-cases/02.a-run-basic-test-local.md
@@ -1,0 +1,59 @@
+# Use Case: 02.a - Run Basic Mutation Test (Local Distributor)
+
+## Description
+This use case describes running a basic mutation test using Cosmic Ray
+with the local distributor selected during configuration.
+
+## Actor
+RooCode Agent
+
+## Preconditions
+- Preconditions from **Use Case 02** apply.
+- The project test suite passes.
+
+## Flow
+1. **Select Local Distributor:**
+   - The agent ensures that the Cosmic Ray configuration specifies the local distributor.
+
+   - If interactive configuration is supported:
+     - During execution of `cosmic-ray new-config`, the agent provides the following information
+       in the interactive prompt:
+       ```
+       [?] Top-level module path: src/my_project/small_file.py
+       [?] Test execution timeout (seconds): 30
+       [?] Test command: pytest test_small_file.py
+       -- MENU: Distributor --
+         (0) http
+         (1) local
+       [?] Enter menu selection: 1
+       ```
+
+   - If interactive configuration is not supported:
+     - The agent creates a `cosmic-ray.toml` file with the following minimal configuration:
+       ```toml
+       [cosmic-ray]
+       module-path = "src/my_project/small_file.py"
+       test-command = "pytest"
+       timeout = 30
+       excluded-modules = []
+
+       [cosmic-ray.distributor]
+       name = "local"
+       ```
+
+2. **Finalize Configuration:**
+   - The configuration file is generated with the local distributor.
+
+3. **Execute Mutation Testing:**
+   - The agent proceeds with mutation testing as defined in steps 4–7 of **Use Case 02**.
+
+## Postconditions
+- Mutation testing is executed locally.
+- No external workers are required.
+
+## Source
+This use case is a specialization of:
+- "[Run Basic Mutation Test](doc/use-cases/02-run-basic-test.md)"
+
+---
+*Generated/modified by AI RooCode 3.36.2, used model google/gemini-2.5-flash*

--- a/doc/use-cases/02.b-run-basic-test-http.md
+++ b/doc/use-cases/02.b-run-basic-test-http.md
@@ -1,0 +1,87 @@
+# Use Case: 02.b - Run Basic Mutation Test (HTTP Distributor)
+
+## Description
+This use case describes running a basic mutation test using Cosmic Ray
+with the HTTP distributor selected during configuration, enabling
+distributed execution.
+
+## Actor
+RooCode Agent
+
+## Preconditions
+- Preconditions from **Use Case 02** apply.
+- The project test suite passes.
+
+## Flow
+1. **Select HTTP Distributor:**
+   - The agent ensures that the Cosmic Ray configuration specifies the HTTP distributor.
+
+   - If interactive configuration is supported:
+     - During execution of `cosmic-ray new-config`, the agent provides the following information
+       in the interactive prompt:
+       ```
+       [?] Top-level module path: src/my_project/small_file.py
+       [?] Test execution timeout (seconds): 30
+       [?] Test command: pytest test_small_file.py
+       -- MENU: Distributor --
+         (0) http
+         (1) local
+       [?] Enter menu selection: 0
+       ```
+
+   - If interactive configuration is not supported:
+     - The agent creates a `cosmic-ray.toml` file with the following minimal configuration:
+       ```toml
+       [cosmic-ray]
+       module-path = "src/my_project/small_file.py"
+       test-command = "pytest"
+       timeout = 30
+       excluded-modules = []
+
+       [cosmic-ray.distributor]
+       name = "http"
+       ```
+
+2. **Configure HTTP Worker URLs:**
+   - The agent updates the existing Cosmic Ray configuration file
+     to include HTTP distributor worker endpoints.
+   - The distributor type (`http`) is already defined as part of the
+     configuration created in the previous step.
+   - The agent adds or updates the HTTP-specific distributor section
+     with one or more worker URLs.
+   - The configuration file contains the following section:
+     ```toml
+     [cosmic-ray.distributor.http]
+     worker-urls = [
+       "<http-worker-url-1>",
+       "<http-worker-url-2>",
+       "... additional worker URLs ..."
+     ]
+     ```
+
+3. **Start HTTP Workers (External Processes):**
+   - HTTP worker processes are started in separate terminals or processes.
+   - Each worker listens on a host and port corresponding to one of the
+     configured worker URLs.
+   - Example command:
+     ```bash
+     cosmic-ray http-worker --port <PORT>
+     ```
+
+4. **Execute Mutation Testing:**
+   - The agent proceeds with mutation testing as defined in steps 4–7 of **Use Case 02**.
+
+## Limitations
+- HTTP workers must run in parallel terminals.
+- This execution variant exceeds the full automation capabilities of the RooCode Agent.
+
+## Postconditions
+- Mutation testing is executed using distributed HTTP workers.
+- Results are collected in a single session file.
+
+## Source
+This use case is a specialization of:
+- "[Run Basic Mutation Test](doc/use-cases/02-run-basic-test.md)"
+
+---
+*Generated/modified by AI RooCode 3.36.2, used model google/gemini-2.5-flash*


### PR DESCRIPTION
Updated the mutation testing use case to support both interactive and manual creation of the Cosmic Ray configuration.  
Both creation methods now clearly distinguish between Local and HTTP distributor workflows.
